### PR TITLE
Names in pdf

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dinesykmeldte/DineSykmeldteHttpClient.kt
+++ b/src/main/kotlin/no/nav/syfo/dinesykmeldte/DineSykmeldteHttpClient.kt
@@ -5,9 +5,6 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import java.util.Random
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import net.datafaker.Faker
 
 fun interface IDineSykmeldteHttpClient {
@@ -44,18 +41,30 @@ class FakeDineSykmeldteHttpClient : IDineSykmeldteHttpClient {
             orgnummer = faker.numerify("#########"),
             fnr = faker.numerify("###########"),
             navn = faker.name().fullName(),
+            sykmeldinger = listOf(
+                DineSykmeldteSykmelding(
+                    arbeidsgiver = faker.company().name()
+                )
+            ),
             aktivSykmelding = true
         )
     }
 }
 
-@OptIn(ExperimentalSerializationApi::class)
-@Serializable
-@JsonIgnoreUnknownKeys
 data class Sykmeldt(
     val narmestelederId: String,
     val orgnummer: String,
     val fnr: String,
     val navn: String?,
+    val sykmeldinger: List<DineSykmeldteSykmelding>?,
     val aktivSykmelding: Boolean?,
 )
+
+data class DineSykmeldteSykmelding(
+    // respons inneholder mer data, men vi trenger kun dette feltet
+    val arbeidsgiver: String,
+)
+
+fun Sykmeldt.getOrganizationName(): String? {
+    return sykmeldinger?.firstOrNull()?.arbeidsgiver
+}

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanDAO.kt
@@ -51,7 +51,7 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
             skal_deles_med_lege,
             skal_deles_med_veileder,
             created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
         RETURNING uuid
     """.trimIndent()
 
@@ -71,11 +71,11 @@ fun DatabaseInterface.persistOppfolgingsplanAndDeleteUtkast(
             it.setString(3, sykmeldt.narmestelederId)
             it.setString(4, narmesteLederFnr)
             it.setString(5, sykmeldt.orgnummer)
-            it.setString(5, sykmeldt.getOrganizationName())
-            it.setObject(6, createOppfolgingsplanRequest.content.toString(), Types.OTHER)
-            it.setDate(7, Date.valueOf(createOppfolgingsplanRequest.sluttdato.toString()))
-            it.setBoolean(8, createOppfolgingsplanRequest.skalDelesMedLege)
-            it.setBoolean(9, createOppfolgingsplanRequest.skalDelesMedVeileder)
+            it.setString(6, sykmeldt.getOrganizationName())
+            it.setObject(7, createOppfolgingsplanRequest.content.toString(), Types.OTHER)
+            it.setDate(8, Date.valueOf(createOppfolgingsplanRequest.sluttdato.toString()))
+            it.setBoolean(9, createOppfolgingsplanRequest.skalDelesMedLege)
+            it.setBoolean(10, createOppfolgingsplanRequest.skalDelesMedVeileder)
             val resultSet = it.executeQuery()
             resultSet.next()
             resultSet.getObject("uuid", UUID::class.java)

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanUtkastDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/db/OppfolgingsplanUtkastDAO.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.dinesykmeldte.Sykmeldt
 import no.nav.syfo.oppfolgingsplan.dto.CreateUtkastRequest
 import java.sql.Date
 import java.sql.ResultSet
@@ -26,6 +27,8 @@ data class PersistedOppfolgingsplanUtkast (
 
 fun DatabaseInterface.upsertOppfolgingsplanUtkast(
     narmesteLederId: String,
+    narmesteLederFnr: String,
+    sykmeldt: Sykmeldt,
     createUtkastRequest: CreateUtkastRequest,
 ): UUID {
     val statement =
@@ -52,10 +55,10 @@ fun DatabaseInterface.upsertOppfolgingsplanUtkast(
 
     connection.use { connection ->
         connection.prepareStatement(statement).use { preparedStatement ->
-            preparedStatement.setString(1, createUtkastRequest.sykmeldtFnr)
+            preparedStatement.setString(1, sykmeldt.fnr)
             preparedStatement.setString(2, narmesteLederId)
-            preparedStatement.setString(3, createUtkastRequest.narmesteLederFnr)
-            preparedStatement.setString(4, createUtkastRequest.orgnummer)
+            preparedStatement.setString(3, narmesteLederFnr)
+            preparedStatement.setString(4, sykmeldt.orgnummer)
             preparedStatement.setObject(5, createUtkastRequest.content.toString(), Types.OTHER)
             preparedStatement.setDate(6, Date.valueOf(createUtkastRequest.sluttdato.toString()))
             val resultSet = preparedStatement.executeQuery()

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/Oppfolgingsplan.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/Oppfolgingsplan.kt
@@ -30,9 +30,6 @@ data class OppfolgingsplanMetadata (
 )
 
 data class CreateUtkastRequest(
-    val sykmeldtFnr: String,
-    val narmesteLederFnr: String,
-    val orgnummer: String,
     val content: JsonNode?,
     val sluttdato: LocalDate?,
 )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/Oppfolgingsplan.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/dto/Oppfolgingsplan.kt
@@ -8,9 +8,6 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class CreateOppfolgingsplanRequest (
-    val sykmeldtFnr: String,
-    val narmesteLederFnr: String,
-    val orgnummer: String,
     val content: JsonNode,
     val sluttdato: LocalDate,
     val skalDelesMedLege: Boolean,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.oppfolgingsplan.service
 
 import java.time.LocalDate
 import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.dinesykmeldte.Sykmeldt
 import no.nav.syfo.oppfolgingsplan.db.PersistedOppfolgingsplan
 import no.nav.syfo.oppfolgingsplan.db.PersistedOppfolgingsplanUtkast
 import no.nav.syfo.oppfolgingsplan.db.findAllOppfolgingsplanerBy
@@ -18,6 +19,7 @@ import java.util.UUID
 import no.nav.syfo.oppfolgingsplan.dto.SykmeldtOppfolgingsplanOverview
 import no.nav.syfo.oppfolgingsplan.dto.mapToOppfolgingsplanMetadata
 import no.nav.syfo.oppfolgingsplan.dto.mapToUtkastMetadata
+import no.nav.syfo.util.logger
 import no.nav.syfo.varsel.EsyfovarselProducer
 import no.nav.syfo.varsel.domain.ArbeidstakerHendelse
 import no.nav.syfo.varsel.domain.HendelseType
@@ -27,12 +29,22 @@ class OppfolgingsplanService(
     private val database: DatabaseInterface,
     private val esyfovarselProducer: EsyfovarselProducer,
 ) {
+    private val logger = logger()
 
-    fun persistOppfolgingsplan(
-        narmesteLederId: String,
+    fun createOppfolgingsplan(
+        narmesteLederFnr: String,
+        sykmeldt: Sykmeldt,
         createOppfolgingsplanRequest: CreateOppfolgingsplanRequest
     ): UUID {
-        return database.persistOppfolgingsplanAndDeleteUtkast(narmesteLederId, createOppfolgingsplanRequest)
+        val uuid = database.persistOppfolgingsplanAndDeleteUtkast(narmesteLederFnr, sykmeldt, createOppfolgingsplanRequest)
+
+        try {
+            produceOppfolgingsplanCreatedVarsel(sykmeldt)
+        } catch (e: Exception) {
+            logger.error("Error when producing kafka message", e)
+        }
+
+        return uuid
     }
 
     fun persistOppfolgingsplanUtkast(narmesteLederId: String, utkast: CreateUtkastRequest) {
@@ -84,13 +96,13 @@ class OppfolgingsplanService(
         )
     }
 
-    fun produceVarsel(oppfolgingsplan: CreateOppfolgingsplanRequest) {
+    private fun produceOppfolgingsplanCreatedVarsel(sykmeldt: Sykmeldt) {
         val hendelse = ArbeidstakerHendelse(
             type = HendelseType.SM_OPPFOLGINGSPLAN_OPPRETTET,
             ferdigstill = false,
-            arbeidstakerFnr = oppfolgingsplan.sykmeldtFnr,
+            arbeidstakerFnr = sykmeldt.fnr,
             data = null,
-            orgnummer = oppfolgingsplan.orgnummer,
+            orgnummer = sykmeldt.orgnummer,
         )
         esyfovarselProducer.sendVarselToEsyfovarsel(hendelse)
     }

--- a/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingsplan/service/OppfolgingsplanService.kt
@@ -47,8 +47,12 @@ class OppfolgingsplanService(
         return uuid
     }
 
-    fun persistOppfolgingsplanUtkast(narmesteLederId: String, utkast: CreateUtkastRequest) {
-        database.upsertOppfolgingsplanUtkast(narmesteLederId, utkast)
+    fun persistOppfolgingsplanUtkast(narmesteLederId: String, narmesteLederFnr: String, sykmeldt: Sykmeldt, utkast: CreateUtkastRequest) {
+        database.upsertOppfolgingsplanUtkast(
+            narmesteLederId,
+            narmesteLederFnr,
+            sykmeldt,
+            utkast)
     }
 
     fun getOppfolgingsplanUtkast(sykmeldtFnr: String, orgnummer: String): PersistedOppfolgingsplanUtkast? {

--- a/src/main/kotlin/no/nav/syfo/pdfgen/PdfGenService.kt
+++ b/src/main/kotlin/no/nav/syfo/pdfgen/PdfGenService.kt
@@ -24,11 +24,11 @@ fun PersistedOppfolgingsplan.toOppfolginsplanPdfV1(): OppfolginsplanPdfV1 = Oppf
     oppfolgingsplan = Oppfolginsplan(
         createdDate = this.createdAt.atZone(ZoneId.of("Europe/Oslo")).toLocalDate(),
         evaluationDate = this.sluttdato,
-        sykmeldtName = "Tester Hansen",
+        sykmeldtName = this.sykmeldtFullName ?: "Sykmeldt Navn",
         sykmeldtFnr = this.sykmeldtFnr,
-        orgName = "Eksempel AS",
+        orgName = this.orgName ?: "Eksempel AS",
         orgnummer = this.orgnummer,
-        narmesteLederName = "Nærmeste Leder",
+        narmesteLederName = this.narmesteLederFullName ?: "Nærmeste Leder",
         sections = listOf(
             Section(
                 id = "tilpassing",

--- a/src/main/resources/db/migration/V3__name_columns.sql
+++ b/src/main/resources/db/migration/V3__name_columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE oppfolgingsplan
+    add COLUMN sykemeldt_full_name VARCHAR(255) NOT NULL DEFAULT '',
+    add COLUMN org_name VARCHAR(255) NOT NULL DEFAULT '',
+    add COLUMN narmeste_leder_full_name VARCHAR(255) NOT NULL DEFAULT '';

--- a/src/main/resources/db/migration/V3__name_columns.sql
+++ b/src/main/resources/db/migration/V3__name_columns.sql
@@ -1,4 +1,4 @@
 ALTER TABLE oppfolgingsplan
-    add COLUMN sykemeldt_full_name VARCHAR(255) NOT NULL DEFAULT '',
+    add COLUMN sykmeldt_full_name VARCHAR(255) NOT NULL DEFAULT '',
     add COLUMN org_name VARCHAR(255) NOT NULL DEFAULT '',
     add COLUMN narmeste_leder_full_name VARCHAR(255) NOT NULL DEFAULT '';

--- a/src/test/kotlin/no/nav/syfo/TestDb.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDb.kt
@@ -3,7 +3,7 @@ package no.nav.syfo
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import no.nav.syfo.application.database.DatabaseInterface
-import no.nav.syfo.oppfolgingsplan.dto.CreateOppfolgingsplanRequest
+import no.nav.syfo.oppfolgingsplan.db.PersistedOppfolgingsplan
 import org.flywaydb.core.Flyway
 import org.slf4j.LoggerFactory
 import org.testcontainers.containers.PostgreSQLContainer
@@ -99,8 +99,7 @@ class TestDB private constructor() {
 }
 
 fun DatabaseInterface.persistOppfolgingsplan(
-    narmesteLederId: String,
-    createOppfolgingsplanRequest: CreateOppfolgingsplanRequest,
+    persistedOppfolgingsplan: PersistedOppfolgingsplan,
 ): UUID {
     val insertStatement = """
         INSERT INTO oppfolgingsplan (
@@ -119,14 +118,14 @@ fun DatabaseInterface.persistOppfolgingsplan(
 
     connection.use { connection ->
         connection.prepareStatement(insertStatement).use {
-            it.setString(1, createOppfolgingsplanRequest.sykmeldtFnr)
-            it.setString(2, narmesteLederId)
-            it.setString(3, createOppfolgingsplanRequest.narmesteLederFnr)
-            it.setString(4, createOppfolgingsplanRequest.orgnummer)
-            it.setObject(5, createOppfolgingsplanRequest.content.toString(), Types.OTHER)
-            it.setDate(6, Date.valueOf(createOppfolgingsplanRequest.sluttdato.toString()))
-            it.setBoolean(7, createOppfolgingsplanRequest.skalDelesMedLege)
-            it.setBoolean(8, createOppfolgingsplanRequest.skalDelesMedVeileder)
+            it.setString(1, persistedOppfolgingsplan.sykmeldtFnr)
+            it.setString(2, persistedOppfolgingsplan.narmesteLederId)
+            it.setString(3, persistedOppfolgingsplan.narmesteLederFnr)
+            it.setString(4, persistedOppfolgingsplan.orgnummer)
+            it.setObject(5, persistedOppfolgingsplan.content.toString(), Types.OTHER)
+            it.setDate(6, Date.valueOf(persistedOppfolgingsplan.sluttdato.toString()))
+            it.setBoolean(7, persistedOppfolgingsplan.skalDelesMedLege)
+            it.setBoolean(8, persistedOppfolgingsplan.skalDelesMedVeileder)
             val resultSet = it.executeQuery()
             connection.commit()
             resultSet.next()

--- a/src/test/kotlin/no/nav/syfo/TestUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/TestUtils.kt
@@ -2,13 +2,7 @@ package no.nav.syfo
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.ktor.client.call.body
-import io.ktor.client.request.HttpRequest
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.request
-import io.ktor.http.HttpStatusCode
-import io.mockk.coEvery
-import io.mockk.mockk
+import no.nav.syfo.dinesykmeldte.DineSykmeldteSykmelding
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -70,17 +64,8 @@ fun defaultSykmeldt() = Sykmeldt(
     "orgnummer",
     "12345678901",
     "Navn Sykmeldt",
+    sykmeldinger = listOf(DineSykmeldteSykmelding("Test AS")),
     true,
 )
 
 val generatedPdfStandin = "whatever".toByteArray(Charsets.UTF_8)
-
-fun mockHttpResponse(message: String, statusCode: HttpStatusCode): HttpResponse {
-    val mockHttpResponse = mockk<HttpResponse>()
-    val request = mockk<HttpRequest>()
-
-    coEvery { mockHttpResponse.status } returns statusCode
-    coEvery { mockHttpResponse.body<String>() } returns message
-    coEvery { mockHttpResponse.request } returns request
-    return mockHttpResponse
-}

--- a/src/test/kotlin/no/nav/syfo/TestUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/TestUtils.kt
@@ -28,9 +28,6 @@ fun defaultUtkast() = CreateUtkastRequest(
 )
 
 fun defaultOppfolgingsplan() = CreateOppfolgingsplanRequest(
-    sykmeldtFnr = "12345678901",
-    narmesteLederFnr = "10987654321",
-    orgnummer = "orgnummer",
     content = ObjectMapper().readValue(
         """
         {
@@ -44,20 +41,25 @@ fun defaultOppfolgingsplan() = CreateOppfolgingsplanRequest(
     skalDelesMedVeileder = false,
 )
 
-fun CreateOppfolgingsplanRequest.toPersistedOppfolgingsplan(narmesteLederId: String): PersistedOppfolgingsplan {
-    return PersistedOppfolgingsplan(
-        sykmeldtFnr = sykmeldtFnr,
-        narmesteLederFnr = narmesteLederFnr,
-        orgnummer = orgnummer,
-        content = content,
-        skalDelesMedLege = skalDelesMedLege,
-        skalDelesMedVeileder = skalDelesMedLege,
-        uuid = UUID.randomUUID(),
-        narmesteLederId = narmesteLederId,
-        sluttdato = sluttdato,
-        createdAt = Instant.now()
-    )
-}
+fun defaultPersistedOppfolgingsplan() = PersistedOppfolgingsplan(
+    sykmeldtFnr = "12345678901",
+    narmesteLederFnr = "10987654321",
+    orgnummer = "orgnummer",
+    content = ObjectMapper().readValue(
+        """
+        {
+            "tittel": "Oppfølgingsplan for Navn Sykmeldt",
+            "innhold": "Dette er en testoppfølgingsplan"
+        }
+        """.trimIndent()
+    ),
+    skalDelesMedLege = false,
+    skalDelesMedVeileder = false,
+    uuid = UUID.randomUUID(),
+    narmesteLederId = UUID.randomUUID().toString(),
+    sluttdato = LocalDate.now().plus(30, ChronoUnit.DAYS),
+    createdAt = Instant.now()
+)
 
 fun defaultSykmeldt() = Sykmeldt(
     "123",

--- a/src/test/kotlin/no/nav/syfo/TestUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/TestUtils.kt
@@ -9,13 +9,11 @@ import java.time.temporal.ChronoUnit
 import java.util.*
 import no.nav.syfo.dinesykmeldte.Sykmeldt
 import no.nav.syfo.oppfolgingsplan.db.PersistedOppfolgingsplan
+import no.nav.syfo.oppfolgingsplan.db.PersistedOppfolgingsplanUtkast
 import no.nav.syfo.oppfolgingsplan.dto.CreateOppfolgingsplanRequest
 import no.nav.syfo.oppfolgingsplan.dto.CreateUtkastRequest
 
 fun defaultUtkast() = CreateUtkastRequest(
-    sykmeldtFnr = "12345678901",
-    narmesteLederFnr = "10987654321",
-    orgnummer = "orgnummer",
     content = ObjectMapper().readValue(
         """
         {
@@ -59,6 +57,25 @@ fun defaultPersistedOppfolgingsplan() = PersistedOppfolgingsplan(
     narmesteLederId = UUID.randomUUID().toString(),
     sluttdato = LocalDate.now().plus(30, ChronoUnit.DAYS),
     createdAt = Instant.now()
+)
+
+fun defaultPersistedOppfolgingsplanUtkast() = PersistedOppfolgingsplanUtkast(
+    uuid = UUID.randomUUID(),
+    sykmeldtFnr = "12345678901",
+    narmesteLederId = UUID.randomUUID().toString(),
+    narmesteLederFnr = "10987654321",
+    orgnummer = "orgnummer",
+    content = ObjectMapper().readValue(
+        """
+        {
+            "tittel": "Utkast for Navn Sykmeldt",
+            "innhold": "Dette er et testutkast"
+        }
+        """.trimIndent()
+    ),
+    sluttdato = LocalDate.now().plus(30, ChronoUnit.DAYS),
+    createdAt = Instant.now(),
+    updatedAt = Instant.now(),
 )
 
 fun defaultSykmeldt() = Sykmeldt(

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -245,7 +245,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
                 val existingUUID = testDb.persistOppfolgingsplan(
                     narmesteLederId = narmestelederId,
-                    createOppfolgingsplanRequest = defaultOppfolgingsplan()
+                    persistedOppfolgingsplan = defaultOppfolgingsplan()
                 )
 
                 // Act
@@ -286,11 +286,11 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
                 val firstPlanUUID = testDb.persistOppfolgingsplan(
                     narmesteLederId = narmestelederId,
-                    createOppfolgingsplanRequest = defaultOppfolgingsplan()
+                    persistedOppfolgingsplan = defaultOppfolgingsplan()
                 )
                 val latestPlanUUID = testDb.persistOppfolgingsplan(
                     narmesteLederId = narmestelederId,
-                    createOppfolgingsplanRequest = defaultOppfolgingsplan()
+                    persistedOppfolgingsplan = defaultOppfolgingsplan()
                 )
                 val utkastUUID = testDb.upsertOppfolgingsplanUtkast(
                     narmesteLederId = narmestelederId,
@@ -534,7 +534,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             } returns Unit
             val uuid = testDb.persistOppfolgingsplan(
                 narmesteLederId = narmestelederId,
-                createOppfolgingsplanRequest = defaultOppfolgingsplan()
+                persistedOppfolgingsplan = defaultOppfolgingsplan()
             )
             // Act
             val response = client.post {
@@ -582,7 +582,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             } throws LegeNotFoundException("Lege not found for sykmeldt")
             val uuid = testDb.persistOppfolgingsplan(
                 narmesteLederId = narmestelederId,
-                createOppfolgingsplanRequest = defaultOppfolgingsplan()
+                persistedOppfolgingsplan = defaultOppfolgingsplan()
             )
             // Act
             val response = client.post {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -275,7 +275,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                         any(),
                         any()
                     )
-                } returns TexasIntrospectionResponse(active = true, pid = "userIdentifier", acr = "Level4")
+                } returns TexasIntrospectionResponse(active = true, pid = pidInnlogetBruker, acr = "Level4")
 
                 coEvery { texasClientMock.exchangeTokenForDineSykmeldte(any()) } returns TexasExchangeResponse(
                     "token",
@@ -288,7 +288,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                         narmestelederId,
                         "token"
                     )
-                } returns defaultSykmeldt().copy(narmestelederId = narmestelederId)
+                } returns sykmeldt
 
                 val firstPlanUUID = testDb.persistOppfolgingsplan(
                     defaultPersistedOppfolgingsplan()
@@ -304,6 +304,8 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 )
                 val utkastUUID = testDb.upsertOppfolgingsplanUtkast(
                     narmesteLederId = narmestelederId,
+                    narmesteLederFnr = pidInnlogetBruker,
+                    sykmeldt = sykmeldt,
                     createUtkastRequest = defaultUtkast()
                 )
 
@@ -394,9 +396,12 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 } returns Unit
 
                 testDb.upsertOppfolgingsplanUtkast(
-                    narmestelederId,
-                    defaultUtkast()
+                    narmesteLederId = narmestelederId,
+                    narmesteLederFnr = pidInnlogetBruker,
+                    sykmeldt = sykmeldt,
+                    createUtkastRequest = defaultUtkast()
                 )
+
                 val oppfolgingsplan = defaultOppfolgingsplan()
 
                 // Act
@@ -444,9 +449,12 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             } throws Exception("exception")
 
             testDb.upsertOppfolgingsplanUtkast(
-                narmestelederId,
-                defaultUtkast()
+                narmesteLederId = narmestelederId,
+                narmesteLederFnr = pidInnlogetBruker,
+                sykmeldt = sykmeldt,
+                createUtkastRequest = defaultUtkast()
             )
+            
             val oppfolgingsplan = defaultOppfolgingsplan()
 
             // Act

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanApiV1Test.kt
@@ -32,6 +32,7 @@ import no.nav.syfo.application.exception.ApiError
 import no.nav.syfo.application.exception.ErrorType
 import no.nav.syfo.application.exception.LegeNotFoundException
 import no.nav.syfo.defaultOppfolgingsplan
+import no.nav.syfo.defaultPersistedOppfolgingsplan
 import no.nav.syfo.defaultSykmeldt
 import no.nav.syfo.defaultUtkast
 import no.nav.syfo.dinesykmeldte.DineSykmeldteHttpClient
@@ -61,9 +62,12 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
     val dineSykmeldteHttpClientMock = mockk<DineSykmeldteHttpClient>()
     val esyfovarselProducerMock = mockk<EsyfovarselProducer>()
     val testDb = TestDB.database
-    val narmestelederId = UUID.randomUUID().toString()
     val isDialogmeldingClientMock = mockk<IsDialogmeldingClient>()
     val pdfGenServiceMock = mockk<PdfGenService>()
+
+    val narmestelederId = UUID.randomUUID().toString()
+    val pidInnlogetBruker = "10987654321"
+    val sykmeldt = defaultSykmeldt().copy(narmestelederId = narmestelederId)
 
 
     beforeTest {
@@ -244,8 +248,10 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 } returns defaultSykmeldt().copy(narmestelederId = narmestelederId)
 
                 val existingUUID = testDb.persistOppfolgingsplan(
-                    narmesteLederId = narmestelederId,
-                    persistedOppfolgingsplan = defaultOppfolgingsplan()
+                    defaultPersistedOppfolgingsplan()
+                        .copy(
+                            narmesteLederId = narmestelederId,
+                        )
                 )
 
                 // Act
@@ -285,12 +291,16 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 } returns defaultSykmeldt().copy(narmestelederId = narmestelederId)
 
                 val firstPlanUUID = testDb.persistOppfolgingsplan(
-                    narmesteLederId = narmestelederId,
-                    persistedOppfolgingsplan = defaultOppfolgingsplan()
+                    defaultPersistedOppfolgingsplan()
+                        .copy(
+                            narmesteLederId = narmestelederId,
+                        )
                 )
                 val latestPlanUUID = testDb.persistOppfolgingsplan(
-                    narmesteLederId = narmestelederId,
-                    persistedOppfolgingsplan = defaultOppfolgingsplan()
+                    defaultPersistedOppfolgingsplan()
+                        .copy(
+                            narmesteLederId = narmestelederId,
+                        )
                 )
                 val utkastUUID = testDb.upsertOppfolgingsplanUtkast(
                     narmesteLederId = narmestelederId,
@@ -317,7 +327,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 // Arrange
                 coEvery {
                     texasClientMock.introspectToken(any(), any())
-                } returns TexasIntrospectionResponse(active = true, pid = "userIdentifier", acr = "Level4")
+                } returns TexasIntrospectionResponse(active = true, pid = pidInnlogetBruker, acr = "Level4")
 
                 coEvery {
                     texasClientMock.exchangeTokenForDineSykmeldte(any())
@@ -325,7 +335,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
                 coEvery {
                     dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(narmestelederId, "token")
-                } returns defaultSykmeldt().copy(narmestelederId = narmestelederId)
+                } returns sykmeldt
 
                 coEvery {
                     esyfovarselProducerMock.sendVarselToEsyfovarsel(any())
@@ -345,10 +355,10 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
                 val persisted = testDb.findAllOppfolgingsplanerBy("12345678901", "orgnummer")
                 persisted.size shouldBe 1
-                persisted.first().sykmeldtFnr shouldBe oppfolgingsplan.sykmeldtFnr
-                persisted.first().narmesteLederFnr shouldBe oppfolgingsplan.narmesteLederFnr
+                persisted.first().sykmeldtFnr shouldBe sykmeldt.fnr
+                persisted.first().narmesteLederFnr shouldBe pidInnlogetBruker
                 persisted.first().narmesteLederId shouldBe narmestelederId
-                persisted.first().orgnummer shouldBe oppfolgingsplan.orgnummer
+                persisted.first().orgnummer shouldBe sykmeldt.orgnummer
                 persisted.first().content.toString() shouldBe oppfolgingsplan.content.toString()
                 persisted.first().sluttdato.toString() shouldBe oppfolgingsplan.sluttdato.toString()
                 persisted.first().skalDelesMedLege shouldBe oppfolgingsplan.skalDelesMedLege
@@ -358,8 +368,8 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 verify(exactly = 1) {
                     esyfovarselProducerMock.sendVarselToEsyfovarsel(withArg {
                         val hendelse = it as ArbeidstakerHendelse
-                        hendelse.arbeidstakerFnr shouldBe oppfolgingsplan.sykmeldtFnr
-                        hendelse.orgnummer shouldBe oppfolgingsplan.orgnummer
+                        hendelse.arbeidstakerFnr shouldBe sykmeldt.fnr
+                        hendelse.orgnummer shouldBe sykmeldt.orgnummer
                     })
                 }
             }
@@ -369,7 +379,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 // Arrange
                 coEvery {
                     texasClientMock.introspectToken(any(), any())
-                } returns TexasIntrospectionResponse(active = true, pid = "userIdentifier", acr = "Level4")
+                } returns TexasIntrospectionResponse(active = true, pid = pidInnlogetBruker, acr = "Level4")
 
                 coEvery {
                     texasClientMock.exchangeTokenForDineSykmeldte(any())
@@ -377,7 +387,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
                 coEvery {
                     dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(narmestelederId, "token")
-                } returns defaultSykmeldt().copy(narmestelederId = narmestelederId)
+                } returns sykmeldt
 
                 coEvery {
                     esyfovarselProducerMock.sendVarselToEsyfovarsel(any())
@@ -407,8 +417,8 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 verify(exactly = 1) {
                     esyfovarselProducerMock.sendVarselToEsyfovarsel(withArg {
                         val hendelse = it as ArbeidstakerHendelse
-                        hendelse.arbeidstakerFnr shouldBe oppfolgingsplan.sykmeldtFnr
-                        hendelse.orgnummer shouldBe oppfolgingsplan.orgnummer
+                        hendelse.arbeidstakerFnr shouldBe sykmeldt.fnr
+                        hendelse.orgnummer shouldBe sykmeldt.orgnummer
                     })
                 }
             }
@@ -419,7 +429,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             // Arrange
             coEvery {
                 texasClientMock.introspectToken(any(), any())
-            } returns TexasIntrospectionResponse(active = true, pid = "userIdentifier", acr = "Level4")
+            } returns TexasIntrospectionResponse(active = true, pid = pidInnlogetBruker, acr = "Level4")
 
             coEvery {
                 texasClientMock.exchangeTokenForDineSykmeldte(any())
@@ -427,7 +437,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
             coEvery {
                 dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(narmestelederId, "token")
-            } returns defaultSykmeldt().copy(narmestelederId = narmestelederId)
+            } returns sykmeldt
 
             coEvery {
                 esyfovarselProducerMock.sendVarselToEsyfovarsel(any())
@@ -457,8 +467,8 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             verify(exactly = 1) {
                 esyfovarselProducerMock.sendVarselToEsyfovarsel(withArg {
                     val hendelse = it as ArbeidstakerHendelse
-                    hendelse.arbeidstakerFnr shouldBe oppfolgingsplan.sykmeldtFnr
-                    hendelse.orgnummer shouldBe oppfolgingsplan.orgnummer
+                    hendelse.arbeidstakerFnr shouldBe sykmeldt.fnr
+                    hendelse.orgnummer shouldBe sykmeldt.orgnummer
                 })
             }
         }
@@ -468,25 +478,24 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             // Arrange
             coEvery { texasClientMock.introspectToken(any(), any()) } returns TexasIntrospectionResponse(
                 active = true,
-                pid = "user",
+                pid = pidInnlogetBruker,
                 acr = "Level4"
             )
             coEvery {
                 texasClientMock.exchangeTokenForDineSykmeldte(any())
             } returns TexasExchangeResponse("token", 111, "tokenType")
+
             coEvery {
                 texasClientMock.exchangeTokenForIsDialogmelding(any())
-            } returns TexasExchangeResponse(
-                "token",
-                111,
-                "tokenType"
-            )
+            } returns TexasExchangeResponse("token", 111, "tokenType")
+
             coEvery {
                 dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(
                     narmestelederId,
                     "token"
                 )
-            } returns defaultSykmeldt()
+            } returns sykmeldt
+
             val uuid = UUID.randomUUID()
             // Act
             val response = client.post {
@@ -505,7 +514,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             // Arrange
             coEvery { texasClientMock.introspectToken(any(), any()) } returns TexasIntrospectionResponse(
                 active = true,
-                pid = "user",
+                pid = pidInnlogetBruker,
                 acr = "Level4"
             )
             coEvery {
@@ -523,7 +532,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                     narmestelederId,
                     "token"
                 )
-            } returns defaultSykmeldt()
+            } returns sykmeldt
             coEvery { pdfGenServiceMock.generatePdf(any()) } returns generatedPdfStandin
             coEvery {
                 isDialogmeldingClientMock.sendOppfolgingsplanToGeneralPractitioner(
@@ -533,8 +542,8 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 )
             } returns Unit
             val uuid = testDb.persistOppfolgingsplan(
-                narmesteLederId = narmestelederId,
-                persistedOppfolgingsplan = defaultOppfolgingsplan()
+                defaultPersistedOppfolgingsplan()
+                    .copy(narmesteLederId = narmestelederId)
             )
             // Act
             val response = client.post {
@@ -553,7 +562,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             // Arrange
             coEvery { texasClientMock.introspectToken(any(), any()) } returns TexasIntrospectionResponse(
                 active = true,
-                pid = "user",
+                pid = pidInnlogetBruker,
                 acr = "Level4"
             )
             coEvery {
@@ -571,7 +580,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                     narmestelederId,
                     "token"
                 )
-            } returns defaultSykmeldt()
+            } returns sykmeldt
             coEvery { pdfGenServiceMock.generatePdf(any()) } returns generatedPdfStandin
             coEvery {
                 isDialogmeldingClientMock.sendOppfolgingsplanToGeneralPractitioner(
@@ -581,8 +590,8 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                 )
             } throws LegeNotFoundException("Lege not found for sykmeldt")
             val uuid = testDb.persistOppfolgingsplan(
-                narmesteLederId = narmestelederId,
-                persistedOppfolgingsplan = defaultOppfolgingsplan()
+                defaultPersistedOppfolgingsplan()
+                    .copy(narmesteLederId = narmestelederId)
             )
             // Act
             val response = client.post {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/arbeidsgiver/OppfolgingsplanUtkastApiV1Test.kt
@@ -45,6 +45,7 @@ import java.time.LocalDate
 import no.nav.syfo.pdfgen.PdfGenClient
 import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.varsel.EsyfovarselProducer
+import java.util.UUID
 
 class OppfolgingsplanUtkastApiV1Test : DescribeSpec({
 
@@ -54,6 +55,10 @@ class OppfolgingsplanUtkastApiV1Test : DescribeSpec({
     val esyfovarselProducerMock = mockk<EsyfovarselProducer>()
     val pdfGenClient = mockk<PdfGenClient>()
     val isDialogmeldingClientMock = mockk<IsDialogmeldingClient>()
+
+    val narmestelederId = UUID.randomUUID().toString()
+    val pidInnlogetBruker = "10987654321"
+    val sykmeldt = defaultSykmeldt().copy(narmestelederId = narmestelederId)
 
     beforeTest {
         clearAllMocks()
@@ -98,20 +103,20 @@ class OppfolgingsplanUtkastApiV1Test : DescribeSpec({
                 // Arrange
                 coEvery {
                     texasClientMock.introspectToken(any(), any())
-                } returns TexasIntrospectionResponse(active = true, pid = "userIdentifier", acr = "Level4")
+                } returns TexasIntrospectionResponse(active = true, pid = pidInnlogetBruker, acr = "Level4")
 
                 coEvery {
                     texasClientMock.exchangeTokenForDineSykmeldte(any())
                 } returns TexasExchangeResponse("token", 111, "tokenType")
 
                 coEvery {
-                    dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId("123", "token")
-                } returns defaultSykmeldt()
+                    dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(narmestelederId, "token")
+                } returns sykmeldt
 
                 val utkast = defaultUtkast()
 
                 // Act
-                val response = client.put("/api/v1/arbeidsgiver/123/oppfolgingsplaner/utkast") {
+                val response = client.put("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner/utkast") {
                     bearerAuth("Bearer token")
                     contentType(ContentType.Application.Json)
                     setBody(utkast)
@@ -124,8 +129,8 @@ class OppfolgingsplanUtkastApiV1Test : DescribeSpec({
                 persisted shouldNotBe null
                 persisted?.let {
                     it.sykmeldtFnr shouldBe "12345678901"
-                    it.narmesteLederId shouldBe "123"
-                    it.narmesteLederFnr shouldBe "10987654321"
+                    it.narmesteLederId shouldBe narmestelederId
+                    it.narmesteLederFnr shouldBe pidInnlogetBruker
                     it.orgnummer shouldBe "orgnummer"
                     it.content shouldNotBe null
                     it.sluttdato shouldBe utkast.sluttdato
@@ -138,18 +143,20 @@ class OppfolgingsplanUtkastApiV1Test : DescribeSpec({
                 // Arrange
                 coEvery {
                     texasClientMock.introspectToken(any(), any())
-                } returns TexasIntrospectionResponse(active = true, pid = "userIdentifier", acr = "Level4")
+                } returns TexasIntrospectionResponse(active = true, pid = pidInnlogetBruker, acr = "Level4")
 
                 coEvery {
                     texasClientMock.exchangeTokenForDineSykmeldte(any())
                 } returns TexasExchangeResponse("token", 111, "tokenType")
 
                 coEvery {
-                    dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId("123", "token")
-                } returns defaultSykmeldt()
+                    dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(narmestelederId, "token")
+                } returns sykmeldt
 
                 val existingUUID = testDb.upsertOppfolgingsplanUtkast(
-                    "123",
+                    narmesteLederId = narmestelederId,
+                    narmesteLederFnr = pidInnlogetBruker,
+                    sykmeldt = sykmeldt,
                     defaultUtkast()
                         .copy(
                             content = ObjectMapper().readValue(
@@ -163,7 +170,7 @@ class OppfolgingsplanUtkastApiV1Test : DescribeSpec({
                 )
 
                 // Act
-                val response = client.put("/api/v1/arbeidsgiver/123/oppfolgingsplaner/utkast") {
+                val response = client.put("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner/utkast") {
                     bearerAuth("Bearer token")
                     contentType(ContentType.Application.Json)
                     setBody(
@@ -186,10 +193,10 @@ class OppfolgingsplanUtkastApiV1Test : DescribeSpec({
                 persisted shouldNotBe null
                 persisted?.let {
                     it.uuid shouldBe existingUUID
-                    it.sykmeldtFnr shouldBe "12345678901"
-                    it.narmesteLederId shouldBe "123"
-                    it.narmesteLederFnr shouldBe "10987654321"
-                    it.orgnummer shouldBe "orgnummer"
+                    it.sykmeldtFnr shouldBe sykmeldt.fnr
+                    it.narmesteLederId shouldBe narmestelederId
+                    it.narmesteLederFnr shouldBe pidInnlogetBruker
+                    it.orgnummer shouldBe sykmeldt.orgnummer
                     it.content?.get("innhold")?.asText() shouldBe "Nytt innhold"
                     it.sluttdato shouldBe LocalDate.parse("2020-01-02")
                 }
@@ -201,23 +208,26 @@ class OppfolgingsplanUtkastApiV1Test : DescribeSpec({
                 // Arrange
                 coEvery {
                     texasClientMock.introspectToken(any(), any())
-                } returns TexasIntrospectionResponse(active = true, pid = "userIdentifier", acr = "Level4")
+                } returns TexasIntrospectionResponse(active = true, pid = pidInnlogetBruker, acr = "Level4")
 
                 coEvery {
                     texasClientMock.exchangeTokenForDineSykmeldte(any())
                 } returns TexasExchangeResponse("token", 111, "tokenType")
 
                 coEvery {
-                    dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId("123", "token")
-                } returns defaultSykmeldt()
+                    dineSykmeldteHttpClientMock.getSykmeldtForNarmesteLederId(narmestelederId, "token")
+                } returns sykmeldt
 
                 val requestUtkast = defaultUtkast()
                 val existingUUID = testDb.upsertOppfolgingsplanUtkast(
-                    "123", requestUtkast
+                    narmesteLederId = narmestelederId,
+                    narmesteLederFnr = pidInnlogetBruker,
+                    sykmeldt = sykmeldt,
+                    requestUtkast
                 )
 
                 // Act
-                val response = client.get("/api/v1/arbeidsgiver/123/oppfolgingsplaner/utkast") {
+                val response = client.get("/api/v1/arbeidsgiver/$narmestelederId/oppfolgingsplaner/utkast") {
                     bearerAuth("Bearer token")
                 }
 
@@ -226,9 +236,9 @@ class OppfolgingsplanUtkastApiV1Test : DescribeSpec({
                 val utkast = response.body<PersistedOppfolgingsplanUtkast>()
                 utkast shouldNotBe null
                 utkast.uuid shouldBe existingUUID
-                utkast.sykmeldtFnr shouldBe "12345678901"
-                utkast.narmesteLederFnr shouldBe "10987654321"
-                utkast.orgnummer shouldBe "orgnummer"
+                utkast.sykmeldtFnr shouldBe sykmeldt.fnr
+                utkast.narmesteLederFnr shouldBe pidInnlogetBruker
+                utkast.orgnummer shouldBe sykmeldt.orgnummer
                 utkast.content?.get("innhold")?.asText() shouldBe "Dette er en testoppfølgingsplan"
                 utkast.sluttdato shouldBe requestUtkast.sluttdato
             }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
@@ -203,13 +203,13 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
                     val firstPlanUUID = testDb.persistOppfolgingsplan(
                         narmesteLederId = narmestelederId,
-                        createOppfolgingsplanRequest = oppfolgingsplan.copy(
+                        persistedOppfolgingsplan = oppfolgingsplan.copy(
                             sluttdato = LocalDate.now().minus(45, ChronoUnit.DAYS)
                         )
                     )
                     val latestPlanUUID = testDb.persistOppfolgingsplan(
                         narmesteLederId = narmestelederId,
-                        createOppfolgingsplanRequest = oppfolgingsplan
+                        persistedOppfolgingsplan = oppfolgingsplan
                     )
                     testDb.upsertOppfolgingsplanUtkast(
                         narmesteLederId = narmestelederId,
@@ -280,7 +280,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
                     val existingUUID = testDb.persistOppfolgingsplan(
                         narmesteLederId = narmestelederId,
-                        createOppfolgingsplanRequest = oppfolgingsplan
+                        persistedOppfolgingsplan = oppfolgingsplan
                     )
 
                     // Act
@@ -318,7 +318,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
                     val existingUUID = testDb.persistOppfolgingsplan(
                         narmesteLederId = narmestelederId,
-                        createOppfolgingsplanRequest = oppfolgingsplan.copy(sykmeldtFnr = "12345678902")
+                        persistedOppfolgingsplan = oppfolgingsplan.copy(sykmeldtFnr = "12345678902")
                     )
 
                     // Act
@@ -384,7 +384,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
                     val existingUUID = testDb.persistOppfolgingsplan(
                         narmesteLederId = narmestelederId,
-                        createOppfolgingsplanRequest = oppfolgingsplan
+                        persistedOppfolgingsplan = oppfolgingsplan
                     )
 
                     // Act
@@ -425,7 +425,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
 
                     val existingUUID = testDb.persistOppfolgingsplan(
                         narmesteLederId = narmestelederId,
-                        createOppfolgingsplanRequest = oppfolgingsplan
+                        persistedOppfolgingsplan = oppfolgingsplan
                     )
 
                     // Act

--- a/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingsplan/api/v1/sykmeldt/OppfolgingsplanApiV1Test.kt
@@ -29,18 +29,18 @@ import java.time.temporal.ChronoUnit
 import java.util.*
 import no.nav.syfo.TestDB
 import no.nav.syfo.defaultPersistedOppfolgingsplan
-import no.nav.syfo.defaultUtkast
+import no.nav.syfo.defaultPersistedOppfolgingsplanUtkast
 import no.nav.syfo.dinesykmeldte.DineSykmeldteHttpClient
 import no.nav.syfo.dinesykmeldte.DineSykmeldteService
 import no.nav.syfo.generatedPdfStandin
 import no.nav.syfo.isdialogmelding.IsDialogmeldingService
 import no.nav.syfo.oppfolgingsplan.api.v1.registerApiV1
 import no.nav.syfo.oppfolgingsplan.db.PersistedOppfolgingsplan
-import no.nav.syfo.oppfolgingsplan.db.upsertOppfolgingsplanUtkast
 import no.nav.syfo.oppfolgingsplan.dto.SykmeldtOppfolgingsplanOverview
 import no.nav.syfo.oppfolgingsplan.service.OppfolgingsplanService
 import no.nav.syfo.pdfgen.PdfGenService
 import no.nav.syfo.persistOppfolgingsplan
+import no.nav.syfo.persistOppfolgingsplanUtkast
 import no.nav.syfo.plugins.installContentNegotiation
 import no.nav.syfo.texas.client.TexasExchangeResponse
 import no.nav.syfo.texas.client.TexasHttpClient
@@ -174,6 +174,7 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
             }
             it("GET /oppfolgingsplaner/oversikt should respond with OK and return overview") {
                 val sykmeldtFnr = "12345678901"
+                val narmestelederFnr = "10987654321"
                 withTestApplication {
                     // Arrange
                     coEvery {
@@ -204,9 +205,13 @@ class OppfolgingsplanApiV1Test : DescribeSpec({
                         defaultPersistedOppfolgingsplan()
                             .copy(narmesteLederId = narmestelederId)
                     )
-                    testDb.upsertOppfolgingsplanUtkast(
-                        narmesteLederId = narmestelederId,
-                        createUtkastRequest = defaultUtkast()
+                    testDb.persistOppfolgingsplanUtkast(
+                        defaultPersistedOppfolgingsplanUtkast()
+                            .copy(
+                                narmesteLederId = narmestelederId,
+                                narmesteLederFnr = narmestelederFnr,
+                                sykmeldtFnr = sykmeldtFnr,
+                            )
                     )
 
                     // Act

--- a/src/test/kotlin/no/nav/syfo/pdfgen/PdfGenServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdfgen/PdfGenServiceTest.kt
@@ -13,9 +13,7 @@ import io.ktor.http.fullPath
 import io.ktor.http.headersOf
 import io.ktor.http.isSuccess
 import io.mockk.clearAllMocks
-import java.util.*
-import no.nav.syfo.defaultOppfolgingsplan
-import no.nav.syfo.toPersistedOppfolgingsplan
+import no.nav.syfo.defaultPersistedOppfolgingsplan
 import no.nav.syfo.util.httpClientDefault
 import org.junit.jupiter.api.assertThrows
 
@@ -48,7 +46,6 @@ class PdfGenServiceTest : DescribeSpec({
 
     describe("PdfGenService") {
         it("generatePdf and outgoing call with client succeeds") {
-            val plan = defaultOppfolgingsplan()
             val client = httpClientDefault(
                 HttpClient(
                     getMockEngine(
@@ -56,7 +53,7 @@ class PdfGenServiceTest : DescribeSpec({
                     )
                 )
             )
-            val persistedPlan = plan.toPersistedOppfolgingsplan(UUID.randomUUID().toString())
+            val persistedPlan = defaultPersistedOppfolgingsplan()
             val myService = PdfGenService(PdfGenClient(client, ""))
             val response = myService.generatePdf(persistedPlan)
             response shouldNotBe null
@@ -74,8 +71,7 @@ class PdfGenServiceTest : DescribeSpec({
                 )
             )
             val myService = PdfGenService(PdfGenClient(client, ""))
-            val plan = defaultOppfolgingsplan()
-            val persistedPlan = plan.toPersistedOppfolgingsplan(UUID.randomUUID().toString())
+            val persistedPlan = defaultPersistedOppfolgingsplan()
             assertThrows<RuntimeException> {
                 myService.generatePdf(persistedPlan)
             }


### PR DESCRIPTION
Nye kolonner `sykmeldt_full_name`, `org_name`, `narmeste_leder_full_name` i tabellen `oppfolgingsplan`.
Navnet for sykmeldt og bedrift blir lagret ved opprettelse av oppfølgingsplan siden vi allerede har dette tilgjengelig via dinesykmeldte-backend. Navn for nærmeste leder må hentes via PDL. Tar dette i en egen PR for å unngå store PR'er.

Har også fjernet `sykmeldtFnr`, `narmesteLederFnr` og `orgnummer` fra CreateOppfolgingsplanRequest og CreateUtkastRequest siden dette ikke trenger å sendes via body. Blir også mindre validering av data på denne måten.